### PR TITLE
Add standard type colours and use for graph editor.

### DIFF
--- a/modules/praxislive.core.ui/src/main/java/org/praxislive/ide/core/ui/api/TypeColor.java
+++ b/modules/praxislive.core.ui/src/main/java/org/praxislive/ide/core/ui/api/TypeColor.java
@@ -1,0 +1,95 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright 2025 Neil C Smith.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 3 for more details.
+ *
+ * You should have received a copy of the GNU General Public License version 3
+ * along with this work; if not, see http://www.gnu.org/licenses/
+ *
+ *
+ * Please visit https://www.praxislive.org if you need additional information or
+ * have any questions.
+ */
+package org.praxislive.ide.core.ui.api;
+
+import java.awt.Color;
+import javax.swing.UIManager;
+
+/**
+ * Standard colours that can be assigned to various entities to differentiate
+ * them by type (eg. port type or component type).
+ *
+ */
+public enum TypeColor {
+
+    Red("TypeColor.Red", 350f),
+    Orange("TypeColor.Orange", 30f),
+    Yellow("TypeColor.Yellow", 50f),
+    Green("TypeColor.Green", 90f),
+    Cyan("TypeColor.Cyan", 170f),
+    Blue("TypeColor.Blue", 195f),
+    Purple("TypeColor.Purple", 285f),
+    Magenta("TypeColor.Magenta", 315f);
+
+    private final Color selection;
+    private final Color shade;
+    private final Color text;
+
+    private TypeColor(String key, float defaultHue) {
+        Color uiShade = UIManager.getColor(key);
+        Color uiSelection = UIManager.getColor(key + ".selected");
+        Color uiText = UIManager.getColor(key + ".text");
+        boolean isDark = UIUtils.isDarkTheme();
+        if (uiShade != null && uiSelection != null) {
+            this.shade = uiShade;
+            this.selection = uiSelection;
+            this.text = uiText != null ? uiText : isDark ? uiShade : uiSelection;
+        } else {
+            this.shade = hsb(defaultHue, 50, 90);
+            this.selection = hsb(defaultHue, 95, 85);
+            this.text = isDark ? this.shade : this.selection;
+        }
+    }
+
+    /**
+     * The standard colour to use for graphical elements.
+     *
+     * @return standard colour
+     */
+    public Color shade() {
+        return shade;
+    }
+
+    /**
+     * The selection colour variant to use for graphical elements.
+     *
+     * @return selection colour
+     */
+    public Color selection() {
+        return selection;
+    }
+
+    /**
+     * The colour variant to use for text against the standard background
+     * colour.
+     *
+     * @return text colour
+     */
+    public Color text() {
+        return text;
+    }
+
+    private static Color hsb(float hue, float saturation, float brightness) {
+        return new Color(Color.HSBtoRGB(hue / 360, saturation / 100, brightness / 100));
+    }
+
+}

--- a/modules/praxislive.core.ui/src/main/java/org/praxislive/ide/core/ui/api/UIUtils.java
+++ b/modules/praxislive.core.ui/src/main/java/org/praxislive/ide/core/ui/api/UIUtils.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2024 Neil C Smith.
+ * Copyright 2025 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 3 only, as
@@ -19,31 +19,23 @@
  * Please visit https://www.praxislive.org if you need additional information or
  * have any questions.
  */
-package org.praxislive.ide.pxr.graph;
+package org.praxislive.ide.core.ui.api;
 
-import org.praxislive.ide.pxr.graph.scene.LAFScheme;
+import javax.swing.UIManager;
 
 /**
  *
  */
-enum Colors {
+final class UIUtils {
 
-    Default(LAFScheme.DEFAULT_COLORS), // new LAFScheme.Colors(new Color(0x748cc0), new Color(0xbacdf0))
-    Red(LAFScheme.RED),
-    Green(LAFScheme.GREEN),
-    Blue(LAFScheme.BLUE),
-    Purple(LAFScheme.PURPLE),
-    Orange(LAFScheme.ORANGE),
-    Yellow(LAFScheme.YELLOW);
+    private static final boolean IS_DARK = UIManager.getBoolean("nb.dark.theme");
+    
+    private UIUtils() {
 
-    private final LAFScheme.Colors schemeColors;
-
-    private Colors(LAFScheme.Colors schemeColors) {
-        this.schemeColors = schemeColors;
     }
 
-    LAFScheme.Colors getSchemeColors() {
-        return schemeColors;
+    public static boolean isDarkTheme() {
+        return IS_DARK;
     }
-
+    
 }

--- a/modules/praxislive.pxr.graph/src/main/java/org/praxislive/ide/pxr/graph/GraphEditor.java
+++ b/modules/praxislive.pxr.graph/src/main/java/org/praxislive/ide/pxr/graph/GraphEditor.java
@@ -118,6 +118,7 @@ import org.praxislive.ide.core.api.Disposable;
 import org.praxislive.ide.core.api.Task;
 import org.praxislive.ide.project.api.PraxisProject;
 import org.praxislive.ide.pxr.api.Attributes;
+import org.praxislive.ide.pxr.graph.scene.LAFScheme;
 
 /**
  *
@@ -480,7 +481,7 @@ public final class GraphEditor implements RootEditor {
     private void buildChild(String id, final ComponentProxy cmp) {
         String name = cmp instanceof ContainerProxy ? id + "/.." : id;
         NodeWidget widget = scene.addNode(id, name);
-        widget.setSchemeColors(Utils.colorsForComponent(cmp).getSchemeColors());
+        widget.setSchemeColors(Utils.colorsForComponent(cmp));
         widget.setToolTipText(cmp.getType().toString());
         configureWidgetFromAttributes(widget, cmp);
         if (cmp instanceof ContainerProxy) {
@@ -650,15 +651,12 @@ public final class GraphEditor implements RootEditor {
     }
 
     private void buildPin(String cmpID, ComponentProxy cmp, String pinID, PortInfo info) {
-        boolean primary = info.portType().startsWith("Audio")
-                || info.portType().startsWith("Video");
+        boolean primary = !info.portType().startsWith("Control");
         PinWidget pin = scene.addPin(cmpID, pinID, getPinAlignment(info));
-        pin.setSchemeColors(Utils.colorsForPortType(info.portType()).getSchemeColors());
+        pin.setSchemeColors(Utils.colorsForPortType(info.portType()));
         Font font = pin.getFont();
         if (primary) {
             pin.setFont(font.deriveFont(Font.BOLD));
-        } else {
-//            pin.setFont(font.deriveFont(font.getSize2D() * 0.85f));
         }
         String category = info.properties().getString("category", "");
         if (category.isEmpty()) {

--- a/modules/praxislive.pxr.graph/src/main/java/org/praxislive/ide/pxr/graph/Utils.java
+++ b/modules/praxislive.pxr.graph/src/main/java/org/praxislive/ide/pxr/graph/Utils.java
@@ -21,8 +21,11 @@
  */
 package org.praxislive.ide.pxr.graph;
 
+import java.util.Locale;
+import org.praxislive.ide.core.ui.api.TypeColor;
 import org.praxislive.ide.model.ComponentProxy;
 import org.praxislive.ide.model.ContainerProxy;
+import org.praxislive.ide.pxr.graph.scene.LAFScheme;
 
 /**
  *
@@ -32,30 +35,43 @@ class Utils {
     private Utils() {
     }
 
-    static Colors colorsForPortType(String type) {
-        return colorsForString(type);
+    static LAFScheme.Colors colorsForPortType(String type) {
+        return LAFScheme.Colors.forTypeColor(typeColorForString(type, true));
     }
 
-    static Colors colorsForComponent(ComponentProxy cmp) {
+    static LAFScheme.Colors colorsForComponent(ComponentProxy cmp) {
         if (cmp instanceof ContainerProxy) {
-            return Colors.Orange;
+            return LAFScheme.Colors.forTypeColor(TypeColor.Orange);
         } else {
-            return colorsForString(cmp.getType().toString());
+            return LAFScheme.Colors.forTypeColor(
+                    typeColorForString(cmp.getType().toString(), false));
         }
     }
 
-    private static Colors colorsForString(String string) {
-        String test = string.toLowerCase();
+    private static TypeColor typeColorForString(String string, boolean port) {
+        String test = string.toLowerCase(Locale.ROOT);
         if (test.startsWith("audio")) {
-            return Colors.Green;
+            return TypeColor.Green;
         }
         if (test.startsWith("video")) {
-            return Colors.Purple;
+            return TypeColor.Purple;
         }
-        if (test.startsWith("data")) {
-            return Colors.Red;
+        if (port) {
+            if (test.startsWith("control")) {
+                return TypeColor.Blue;
+            }
+            if (test.startsWith("ref")) {
+                return TypeColor.Cyan;
+            }
+        } else {
+            if (test.startsWith("core")) {
+                return TypeColor.Blue;
+            }
+            if (test.startsWith("data")) {
+                return TypeColor.Red;
+            }
         }
-        return Colors.Blue;
+        return TypeColor.Magenta;
     }
 
 }

--- a/modules/praxislive.pxr.graph/src/main/java/org/praxislive/ide/pxr/graph/scene/LAFScheme.java
+++ b/modules/praxislive.pxr.graph/src/main/java/org/praxislive/ide/pxr/graph/scene/LAFScheme.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2024 Neil C Smith.
+ * Copyright 2025 Neil C Smith.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 3 only, as
@@ -46,6 +46,7 @@ import java.awt.BasicStroke;
 import java.awt.Color;
 import java.awt.Font;
 import java.awt.Image;
+import java.util.Map;
 import org.netbeans.api.visual.border.Border;
 import org.netbeans.api.visual.border.BorderFactory;
 import org.netbeans.api.visual.model.ObjectState;
@@ -54,8 +55,11 @@ import org.netbeans.api.visual.anchor.AnchorShape;
 import org.netbeans.api.visual.anchor.PointShape;
 import org.openide.util.ImageUtilities;
 
-import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.swing.UIManager;
+import org.praxislive.ide.core.ui.api.TypeColor;
 
 public final class LAFScheme {
 
@@ -63,57 +67,17 @@ public final class LAFScheme {
 
     public static final Color FOREGROUND
             = findColor("praxis.graph.foreground",
-                    IS_DARK ? new Color(0xf1f9fd) : new Color(0x191919));
+                    IS_DARK ? new Color(0xf2f2f2) : new Color(0x191919));
 
     public static final Color BACKGROUND
             = findColor("praxis.graph.background",
-                    IS_DARK ? new Color(0x191919) : new Color(0xf1f9fd));
+                    IS_DARK ? new Color(0x191919) : new Color(0xf0f0f0));
 
     public static final Color NODE_BACKGROUND
             = findColor("praxis.graph.node.background",
-                    IS_DARK ? new Color(0x121212) : new Color(0xf7fdff));
+                    IS_DARK ? new Color(0x121212) : new Color(0xf7f7f7));
 
-    public static final Colors DEFAULT_COLORS
-            = new Colors(
-                    findColor("praxis.graph.default.selected", new Color(0x748cc0)),
-                    findColor("praxis.graph.default", new Color(0xbacdf0))
-            );
-
-    public static final Colors RED
-            = new Colors(
-                    findColor("praxis.graph.red.selected", new Color(0xff2a2a)),
-                    findColor("praxis.graph.red", new Color(0xff8080))
-            );
-
-    public static final Colors GREEN
-            = new Colors(
-                    findColor("praxis.graph.green.selected", new Color(0xaad400)),
-                    findColor("praxis.graph.green", new Color(0xc6d976))
-            );
-
-    public static final Colors BLUE
-            = new Colors(
-                    findColor("praxis.graph.blue.selected", new Color(0x748cc0)),
-                    findColor("praxis.graph.blue", new Color(0xbacdf0))
-            );
-
-    public static final Colors PURPLE
-            = new Colors(
-                    findColor("praxis.graph.green.selected", new Color(0xd42aff)),
-                    findColor("praxis.graph.green", new Color(0xe580ff))
-            );
-
-    public static final Colors ORANGE
-            = new Colors(
-                    findColor("praxis.graph.green.selected", new Color(0xff9126)),
-                    findColor("praxis.graph.green", new Color(0xffb46a))
-            );
-
-    public static final Colors YELLOW
-            = new Colors(
-                    findColor("praxis.graph.green.selected", new Color(0xf9f900)),
-                    findColor("praxis.graph.green", new Color(0xffff7a))
-            );
+    public static final Colors DEFAULT_COLORS = Colors.TYPE_COLOR_MAP.get(TypeColor.Cyan);
 
     private static final Border BORDER_MINIMIZE
             = BorderFactory.createOpaqueBorder(2, 2, 2, 2);
@@ -194,7 +158,7 @@ public final class LAFScheme {
         Widget header = widget.getHeader();
         header.setBorder(state.isSelected() || state.isHovered()
                 ? colors.BORDER_HEADER_SELECTED : colors.BORDER_HEADER);
-        Color auxFG = IS_DARK ? colors.COLOR_NORMAL : colors.COLOR_SELECTED;
+        Color auxFG = colors.COLOR_TEXT;
         Widget comment = widget.getCommentWidget();
         comment.setForeground(auxFG);
         comment.setFont(commentFont);
@@ -259,8 +223,7 @@ public final class LAFScheme {
         if (colors == null) {
             colors = DEFAULT_COLORS;
         }
-        widget.getPinNameWidget().setForeground(IS_DARK
-                ? colors.COLOR_NORMAL : colors.COLOR_SELECTED);
+        widget.getPinNameWidget().setForeground(colors.COLOR_TEXT);
         if (state.isHovered()) {
             widget.setBorder(colors.BORDER_PIN_SELECTED);
         } else {
@@ -284,8 +247,14 @@ public final class LAFScheme {
 
     public static class Colors {
 
+        private static final Map<TypeColor, Colors> TYPE_COLOR_MAP = Map.copyOf(
+                Stream.of(TypeColor.values())
+                        .collect(Collectors.toMap(Function.identity(), Colors::new))
+        );
+
         private final Color COLOR_SELECTED;
         private final Color COLOR_NORMAL;
+        private final Color COLOR_TEXT;
 
         private final Border BORDER_NODE;
         private final Border BORDER_NODE_FOCUSED;
@@ -303,9 +272,10 @@ public final class LAFScheme {
         private final Border BORDER_PIN;
         private final Border BORDER_PIN_SELECTED;
 
-        public Colors(Color highlight, Color normal) {
-            COLOR_SELECTED = Objects.requireNonNull(highlight);
-            COLOR_NORMAL = Objects.requireNonNull(normal);
+        public Colors(TypeColor typeColor) {
+            COLOR_SELECTED = typeColor.selection();
+            COLOR_NORMAL = typeColor.shade();
+            COLOR_TEXT = typeColor.text();
             BORDER_NODE = BorderFactory.createCompositeBorder(
                     BorderFactory.createEmptyBorder(2),
                     BorderFactory.createRoundedBorder(8, 8, 0, 0, NODE_BACKGROUND, COLOR_NORMAL));
@@ -337,6 +307,10 @@ public final class LAFScheme {
 
             BORDER_PIN = BorderFactory.createRoundedBorder(8, 8, 8, 4, null, null);
             BORDER_PIN_SELECTED = BorderFactory.createRoundedBorder(8, 8, 8, 4, null, COLOR_NORMAL);
+        }
+
+        public static Colors forTypeColor(TypeColor typeColor) {
+            return TYPE_COLOR_MAP.getOrDefault(typeColor, DEFAULT_COLORS);
         }
 
     }


### PR DESCRIPTION
Add 8 standard type colours. Update graph editor to use type colours. Use different colouring for custom components outside of core: hierarchy.  Use different colours for ref and data port types.  Make all port names bold unless control ports.